### PR TITLE
Fix missing colon in division function

### DIFF
--- a/missing_colon.py
+++ b/missing_colon.py
@@ -1,9 +1,5 @@
-#!/usr/bin/env python3
-
-
-def division(a: float, b: float) -> float
+def division(a: float, b: float) -> float:
     return a/b
-
 
 if __name__ == "__main__":
     print(division(23, 0))


### PR DESCRIPTION
Closes #1: Fixes syntax error in missing_colon.py by adding the missing colon in the division function definition.