### PR TITLE
Fix SyntaxError in missing_colon.py

### DIFF
--- a/missing_colon.py
+++ b/missing_colon.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 
-def division(a: float, b: float) -> float
+def division(a: float, b: float) -> float:
     return a/b
 
 


### PR DESCRIPTION
This PR fixes the SyntaxError caused by a missing colon in the function definition of `division` in `missing_colon.py`.