### PR TITLE
Fix SyntaxError in division function

### DIFF
--- a/missing_colon.py
+++ b/missing_colon.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python3
-
-def division(a: float, b: float) -> float:
+def division(a, b):
     return a/b
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #2
Fixed SyntaxError by adding a colon to the function definition in missing_colon.py