### PR TITLE
Fix SyntaxError in missing_colon.py

### DIFF
--- a/missing_colon.py
+++ b/missing_colon.py
@@ -1,2 +1,2 @@
-def division(a, b)
+def division(a, b):
     return a / b


### PR DESCRIPTION
This pull request fixes the SyntaxError caused by a missing colon in the function definition of `division`. The corrected code now includes the colon, ensuring proper syntax.