### PR TITLE
Fix SyntaxError in missing_colon.py

### DIFF
--- a/missing_colon.py
+++ b/missing_colon.py
@@ -1,2 +1,1 @@
-def division(a, b)
-    return a / b
+def division(a, b): return a / b


### PR DESCRIPTION
This pull request fixes the syntax error in the `missing_colon.py` file by adding the missing colon after the function definition.