### PR TITLE
Fix syntax error in division function

### DIFF
--- a/missing_colon.py
+++ b/missing_colon.py
@@ -1,2 +1,2 @@
-def division(a, b)
+def division(a: float, b: float) -> float:
     return a / b


### PR DESCRIPTION
Resolves SyntaxError in missing_colon.py by adding colons to the function definition and return type annotation.