### PR TITLE
Fix syntax error in division function

### DIFF
--- a/missing_colon.py
+++ b/missing_colon.py
@@ -1,2 +1,2 @@
-def division(a, b)
+def division(a, b):
     return a / b


### PR DESCRIPTION
Corrected the missing colon in the division function definition to resolve the SyntaxError.