### PR TITLE
SyntaxError: invalid syntax

### DIFF
--- a/missing_colon.py
+++ b/missing_colon.py
@@ -1,4 +1,2 @@
 def division(a, b):
-    if not (isinstance(a, int) and isinstance(b, int)):
-        raise TypeError('Both a and b must be integers.')
     return a / b


### PR DESCRIPTION
I'm running missing_colon.py as follows:

division(23, 0)

but I get the following error:

  File "/Users/fuchur/Documents/24/git_sync/swe-agent-test-repo/tests/./missing_colon.py", line 4
    def division(a: float, b: float) -> float
                                             ^
SyntaxError: invalid syntax