### PR TITLE
Fix syntax error in missing_colon.py

### DIFF
--- a/missing_colon.py
+++ b/missing_colon.py
@@ -1,2 +1,2 @@
-def division(a, b)
+def division(a, b):
     return a / b


### PR DESCRIPTION
Resolves SyntaxError in missing_colon.py by adding a colon to the function definition.